### PR TITLE
طريقة أسهل للتحقق من رقم الهاتف عند الحجز

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,5 +556,8 @@ The n8n server runs a standalone Node.js HTTP service (`service`) alongside n8n 
 - Setup: `bash setup.sh` in the service directory (idempotent)
 - SMS gateway phones: `doctor.termux`, `assistant.termux`, `doctor2.termux` (connected via reverse SSH tunnels through VPS)
 - Telegram subflow: `Dads Clinic-Send Telegram Messages` (workflow ID: `C2F9UQOSqoWTqCg8`)
+- User-initiated verification V2: workflow `Dads Clinic-Verify Phone Number 2` (`wpSDqlKO2iMoUZZ7`) — generates 6-char codes, user sends code via WhatsApp to verify phone number
+- WhatsApp AI Assistant: workflow `Dads Clinic-WhatsApp AI Assistant` (`XlYzvScd6xm3xlBI`) — Claude Haiku 4.5 powered, intercepts verification codes before AI
 - n8n MCP limitation: `update_workflow` replaces entire workflows — too risky for large ones (40+ nodes). For targeted changes, guide user through the n8n UI instead.
+- **n8n SDK tips:** Data table nodes must have `alwaysOutputData: true` or flows terminate silently when a delete/get returns no rows. Reference data tables via `mode: 'list'` (not `mode: 'id'`) for human-readable workflow editing.
 - See [context/analytics-and-tracking.md](context/analytics-and-tracking.md) for full architecture details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,24 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Team & Collaboration Style
+
+This is a family project. Orwa (developer) builds and maintains the site for his father Dr. Mu'men Diraneyya. Brothers Mamoun and Sufian also contribute.
+
+- **Be terse.** No over-explanation. When told "commit and push", just do it.
+- **Visual work is iterative.** Don't implement full UI features in one shot — start with the simplest visible change, get feedback, iterate.
+- **Don't run builds** unless asked. The user has a dev server running with hot-reload.
+- **Don't start the dev server.** Ask the user if needed.
+- **Ask before making data promises.** Don't write policies or documentation claiming deletion processes exist unless you've verified the API supports it (learned from Cal.com data retention page).
+- **The مسيرتنا page** is a deeply personal biography written by the doctor himself. Handle edits with care.
+
+## Git & GitHub
+
+- **This repo is a fork** of `arthelokyo/astrowind`. The `gh` CLI resolves to the upstream by default.
+- **Always specify `--repo mumendiraneyya/clinic_website`** when using `gh pr create` or other `gh` commands.
+- **PR images:** Leave HTML comment markers (`<!-- 📸 -->`) and ask the user to drag-and-drop images in the GitHub UI.
+- **Submodule `n8n`:** Contains n8n workflow backups. Pull with `cd n8n && git pull` before committing if workflows changed.
+
 ## Knowledge Transfer Documents
 
 Human-readable educational materials explaining complex topics encountered in this project:
@@ -546,18 +564,11 @@ PostHog custom events instrument the booking funnel and detect ad fraud. See [co
 
 ### n8n Backend & Local Services
 
-The n8n server runs a standalone Node.js HTTP service (`service`) alongside n8n to handle operations that n8n can no longer do natively (after `executeCommand` and `localFileTrigger` were removed in n8n 2.15.1).
+See [context/n8n-backend.md](context/n8n-backend.md) for complete documentation of all n8n workflows, local services, SMS gateway, WhatsApp AI assistant, and V2 verification.
 
 **Quick reference:**
-- Service location: `/root/dads-clinic-backup/service/` on the n8n server
-- systemd unit: `clinic-service.service`, listens on `127.0.0.1:3847`
-- `POST /validate` — phone number validation via `google-libphonenumber`
-- `POST /send-sms` — async SMS sending via SSH to Termux phones (returns immediately, sends in background)
-- Setup: `bash setup.sh` in the service directory (idempotent)
-- SMS gateway phones: `doctor.termux`, `assistant.termux`, `doctor2.termux` (connected via reverse SSH tunnels through VPS)
-- Telegram subflow: `Dads Clinic-Send Telegram Messages` (workflow ID: `C2F9UQOSqoWTqCg8`)
-- User-initiated verification V2: workflow `Dads Clinic-Verify Phone Number 2` (`wpSDqlKO2iMoUZZ7`) — generates 6-char codes, user sends code via WhatsApp to verify phone number
-- WhatsApp AI Assistant: workflow `Dads Clinic-WhatsApp AI Assistant` (`XlYzvScd6xm3xlBI`) — Claude Haiku 4.5 powered, intercepts verification codes before AI
-- n8n MCP limitation: `update_workflow` replaces entire workflows — too risky for large ones (40+ nodes). For targeted changes, guide user through the n8n UI instead.
-- **n8n SDK tips:** Data table nodes must have `alwaysOutputData: true` or flows terminate silently when a delete/get returns no rows. Reference data tables via `mode: 'list'` (not `mode: 'id'`) for human-readable workflow editing.
-- See [context/analytics-and-tracking.md](context/analytics-and-tracking.md) for full architecture details
+- n8n instance: `https://n8n.orwa.tech` (self-hosted, v2.15.1)
+- Local services: `clinic-service.service` on `127.0.0.1:3847` — `/validate` (phone validation) and `/send-sms` (async SMS)
+- Key workflows: Verify Phone V1 (`dwv7rpf8uHxyum02`), V2 (`wpSDqlKO2iMoUZZ7`), WhatsApp AI (`XlYzvScd6xm3xlBI`), Telegram subflow (`C2F9UQOSqoWTqCg8`)
+- WhatsApp AI: Claude Haiku 4.5, intent classification, verification code interception
+- SMS gateway: Termux phones via reverse SSH tunnels through VPS

--- a/context/analytics-and-tracking.md
+++ b/context/analytics-and-tracking.md
@@ -1,283 +1,109 @@
 # Analytics, Tracking & Ad Fraud Detection
 
-## Background & Goals
+## Background
 
-The clinic website had **zero online bookings** after 6 months live. PostHog session recordings showed users attempting to enter phone numbers but getting rejected. Privacy masking hid what was typed, and numbers rejected by client-side validation never reached the n8n backend — creating a complete blind spot.
+The clinic website had zero online bookings after 6 months. PostHog instrumentation was added to diagnose where users drop off in the booking funnel and detect fraudulent ad traffic.
 
-Additionally, Google display ads were generating fraudulent traffic: accidental clicks from gaming devices that inflate visit counts and waste ad budget.
+## PostHog Setup
 
-**Goals:**
-1. Instrument the entire booking funnel to diagnose where and why users drop off
-2. Detect and quantify fraudulent/low-quality ad traffic
-3. Track WhatsApp CTA usage as a fallback engagement signal
-4. Correlate frontend sessions with backend booking completions via phone number identity
+- **Init:** `src/components/common/PosthogAnalytics.astro` — loads stub, initializes PostHog
+- **Production only:** Skipped on `localhost`, `127.x.x.x`, `*.pages.dev` (staging)
+- **Config:** `src/config.yaml` under `analytics.vendors.posthog` — project `116305`, EU API host
+- **Global access:** `window.posthog?.capture()` safe everywhere — no-ops if not loaded
+- **PostHog MCP:** `mcp__posthog__*` tools for querying data and managing insights. Use `query-run` to test, `insight-create` to save.
 
-## Architecture
+## User Identity Correlation
 
-### PostHog Setup
-
-- **Init:** `src/components/common/PosthogAnalytics.astro` loads the PostHog stub and initializes it
-- **Production only:** PostHog is skipped on `localhost`, `127.x.x.x`, and `*.pages.dev` (staging)
-- **Config:** `src/config.yaml` under `analytics.vendors.posthog` — project ID, EU API host
-- **Global access:** `window.posthog` is available on all pages (production); `window.posthog?.capture()` is safe everywhere since it no-ops if PostHog isn't loaded
-- **CSP:** The `public/_headers` file must whitelist `*.posthog.com`, `*.i.posthog.com`, `*.google-analytics.com`, and `*.cal.com` in `connect-src` and `frame-src` — otherwise the browser blocks analytics and Cal.com embed requests
-
-### MCP Tools
-
-- **PostHog MCP** (`mcp__posthog__*`): Query data, create/update insights, manage dashboards. Use for creating funnels, trends, and alerts. Project ID: `116305`.
-- **n8n MCP** (`mcp__n8n-mcp__*`): Inspect and modify backend workflows. The phone verification workflow ID is `dwv7rpf8uHxyum02`. Use `get_workflow_details` to inspect webhook responses and validation logic. **Limitation:** `update_workflow` replaces the entire workflow via SDK code — too risky for large workflows. For targeted node changes, guide the user to edit in the n8n UI instead.
-- **Chrome DevTools MCP** (`mcp__chrome-devtools__*`): Test events locally by checking browser console for `posthog.capture` calls.
-
-### User Identity Correlation
-
-Frontend and backend events are linked via phone number:
-1. **Frontend:** After phone verification succeeds, `posthog.identify('+' + phone)` links the anonymous browser session to the phone number
-2. **Backend:** n8n fires `booking_completed` via PostHog's server-side capture API (`POST https://eu.i.posthog.com/i/v0/e/`) with `distinct_id` set to the same phone number (e.g., `+962791234567`)
-3. **PostHog** merges both into one user journey, enabling end-to-end funnel analysis from first page visit to confirmed booking
+Frontend and backend events linked via phone number:
+1. Frontend: `posthog.identify('+' + phone)` after phone verification
+2. Backend: n8n fires `booking_completed` via PostHog capture API (`POST https://eu.i.posthog.com/i/v0/e/`) with same phone as `distinct_id`
+3. PostHog merges both into one user journey
 
 ## Booking Funnel Events
 
-### Frontend Events (3 files)
-
-Helper functions live in `PhoneVerification.astro`'s `<script>` block.
-
-#### Events in `src/components/booking/PhoneVerification.astro`
+### PhoneVerification.astro (V1)
 
 | Event | When | Key Properties |
 |-------|------|----------------|
-| `booking_phone_submitted` | User clicks "Send Code" (BEFORE validation) | `phone_raw`, `phone_normalized`, `phone_length_*`, `country_prefix`, `is_jordan`, `method`, `booking_type` |
+| `booking_phone_submitted` | "Send Code" clicked (before validation) | `phone_raw`, `phone_normalized`, `phone_length_*`, `country_prefix`, `is_jordan`, `method`, `booking_type` |
 | `booking_phone_client_rejected` | Client-side `length < 10` rejects | `phone_raw`, `phone_normalized`, `phone_length_normalized`, `country_prefix`, `booking_type` |
 | `booking_code_request_result` | After n8n send-code API response | `success`, `method`, `failure_reason`, `http_status`, `is_jordan`, `booking_type` |
 | `booking_code_entered` | User submits 4-digit code | `booking_type` |
 | `booking_code_result` | After verify-code API response | `success`, `booking_type` |
-| `booking_verified` | Verification complete, token received | `method`, `is_jordan`, `booking_type` |
+| `booking_verified` | Verification complete | `method`, `is_jordan`, `booking_type` |
 
-After `booking_verified`, `posthog.identify('+' + phone)` is called to link the session.
+### PhoneVerificationV2.astro (V2)
 
-#### Events in `src/pages/book.astro`
+| Event | When | Key Properties |
+|-------|------|----------------|
+| `verify_v2_code_generated` | Code generated and shown to user | `booking_type` |
+| `verify_v2_code_matched` | WhatsApp message matched the code | `booking_type` |
+| `verify_v2_expired` | 5-minute code window expired | `booking_type` |
+
+### book.astro
 
 | Event | When | Key Properties |
 |-------|------|----------------|
 | `booking_token_validated` | After stored JWT validation | `token_valid`, `booking_type` |
-| `booking_cal_opened` | Cal.com embed modal opens | `booking_type`, `entry_point: "book_page"` |
+| `booking_cal_opened` | Cal.com embed modal opens | `booking_type`, `entry_point` |
 
-#### Events in `src/pages/index.astro`
+### index.astro
 
 | Event | When | Key Properties |
 |-------|------|----------------|
-| `booking_cal_opened` | Cal.com opens from homepage popup | `booking_type`, `entry_point: "homepage"` |
+| `booking_cal_opened` | Cal.com opens from homepage | `booking_type`, `entry_point: "homepage"` |
 | `whatsapp_cta_clicked` | WhatsApp button clicked | `layout: "mobile" \| "desktop"` |
 
-### Backend Event (n8n workflow)
+### Backend (n8n)
 
 | Event | When | Key Properties |
 |-------|------|----------------|
-| `booking_completed` | n8n confirms booking on Cal.com | `distinct_id: phone` (fired via PostHog server-side API using n8n's PostHog node) |
-
-This fires after the "Confirm Booking on Cal.com" → "Invoke Booking Creation Webhook" chain in the verification workflow. The `distinct_id` is `+{phone}` from the JWT payload, matching what the frontend used in `posthog.identify()`.
+| `booking_completed` | n8n confirms booking on Cal.com | `distinct_id: phone` (PostHog node) |
 
 ### Helper Functions (PhoneVerification.astro)
 
-- `getPhoneMetadata(rawInput, normalized)` — Returns phone properties for events (full or masked depending on flag)
-- `categorizeSendCodeResponse(data, isNetworkError)` — Maps Arabic n8n error messages to enum: `success`, `invalid_number`, `landline`, `validation_failed`, `rate_limited`, `service_down`, `network_error`, `backoff`, `unknown`
-- `getBookingType()` — Reads `?type=` from URL
+- `getPhoneMetadata(rawInput, normalized)` — phone properties for events (full or masked)
+- `categorizeSendCodeResponse(data, isNetworkError)` — maps Arabic n8n errors to: `success`, `invalid_number`, `landline`, `validation_failed`, `rate_limited`, `service_down`, `network_error`, `backoff`, `unknown`
+- `getBookingType()` — reads `?type=` from URL
 
 ### Phone Privacy Flag
 
-`MASK_PHONE_IN_ANALYTICS` (boolean, in PhoneVerification.astro `<script>` block) — when `true`, replaces digits with `X` in `phone_raw` and `phone_normalized`. Currently **`false`** to diagnose input issues. Flip to `true` when no longer needed.
-
-### Backend Failure Reason Mapping
-
-The n8n "Verify Phone Number" workflow returns Arabic error messages. The `categorizeSendCodeResponse` function maps them:
-
-| Arabic substring | `failure_reason` |
-|-----------------|-----------------|
-| `أرضي` | `landline` |
-| `غير صحيح` | `invalid_number` |
-| `لم نتمكن` | `validation_failed` |
-| `الكثير من طلبات` | `rate_limited` |
-| `متعطلة` | `service_down` |
-| (network error) | `network_error` |
-| (other message) | `backoff` |
-| (no message) | `unknown` |
+`MASK_PHONE_IN_ANALYTICS` in PhoneVerification.astro — `true` replaces digits with `X`. Currently **`false`** for diagnostics.
 
 ## Ad Fraud Detection
 
-### Engagement Tracker (`PosthogAnalytics.astro`)
+Lightweight tracker in `PosthogAnalytics.astro` — only activates for ad-attributed visits (has `utm_source`, `gclid`, or `fbclid`). Fires `ad_visit_engagement` on page leave.
 
-A lightweight script that **only activates for ad-attributed visits** (URL contains `utm_source`, `gclid`, or `fbclid`). Fires a single `ad_visit_engagement` event when the visitor leaves.
+| Property | Description |
+|----------|-------------|
+| `time_on_page_seconds` | Time before leaving |
+| `has_scrolled` / `has_clicked` | Any interaction |
+| `max_scroll_depth_pct` | 0-100 |
+| `is_ghost_visit` | **<=5s, no scroll, no click** |
+| `utm_*`, `gclid`, `fbclid` | Full attribution |
+| `screen_width/height`, `device_pixel_ratio`, `is_touch_device` | Device info |
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `time_on_page_seconds` | number | Time before leaving |
-| `has_scrolled` | boolean | Any scroll at all |
-| `has_clicked` | boolean | Any click at all |
-| `max_scroll_depth_pct` | number | 0-100, how far they scrolled |
-| `is_ghost_visit` | boolean | **<=5 seconds AND no scroll AND no click** |
-| `utm_source/medium/campaign/term/content` | string | Full UTM attribution |
-| `gclid` | string | Google Ads click ID |
-| `fbclid` | string | Facebook click ID |
-| `referrer` | string | Full referrer URL |
-| `referring_domain` | string | Referrer hostname |
-| `landing_page` | string | Path user landed on |
-| `screen_width/height` | number | Device screen dimensions |
-| `device_pixel_ratio` | number | Helps identify device type |
-| `is_touch_device` | boolean | Touch = likely phone/tablet/gaming device |
+Zero overhead for organic visitors.
 
-**Zero overhead for organic visitors** — the tracker exits immediately if no ad params are present.
-
-## PostHog Insights (Saved Dashboards)
-
-All insights are favorited and tagged for easy access:
+## PostHog Insights
 
 ### Booking (tag: `booking`)
-1. **[Booking Funnel (Full)](https://eu.posthog.com/project/116305/insights/LGUWwM9U)** — 5-step funnel: Phone Submitted → Code Sent (success) → Phone Verified → Cal.com Opened → Booking Completed
-2. **[Phone Rejection Patterns](https://eu.posthog.com/project/116305/insights/37DxZVg8)** — Client-side rejections broken down by `phone_raw`
-3. **[Backend Phone Rejection Reasons](https://eu.posthog.com/project/116305/insights/AoncriXj)** — Backend failures broken down by `failure_reason`
-4. **[Booking Fallback: WhatsApp After Phone Attempt](https://eu.posthog.com/project/116305/insights/0elBhZDK)** — Users who tried booking then clicked WhatsApp instead ("gave up and called" rate)
-5. **[WhatsApp CTA: All Clicks by Layout](https://eu.posthog.com/project/116305/insights/BQio88Xu)** — Total WhatsApp clicks by mobile/desktop, compare with #4 to see straight-to-WhatsApp vs fallback
+1. [Booking Funnel (Full)](https://eu.posthog.com/project/116305/insights/LGUWwM9U) — Phone Submitted → Code Sent → Verified → Cal.com → Booking Completed
+2. [Phone Rejection Patterns](https://eu.posthog.com/project/116305/insights/37DxZVg8) — client-side rejections by `phone_raw`
+3. [Backend Rejection Reasons](https://eu.posthog.com/project/116305/insights/AoncriXj) — backend failures by `failure_reason`
+4. [WhatsApp Fallback](https://eu.posthog.com/project/116305/insights/0elBhZDK) — users who tried booking then clicked WhatsApp
+5. [WhatsApp CTA Clicks](https://eu.posthog.com/project/116305/insights/BQio88Xu) — all WhatsApp clicks by mobile/desktop
 
 ### Ad Fraud (tags: `ads`, `fraud`)
-4. **[Ad Fraud: Ghost Visits by Source](https://eu.posthog.com/project/116305/insights/0wbhRUXg)** — Ghost visits vs total ad visits by `utm_source`
-5. **[Ad Campaign Quality: Avg Time on Page](https://eu.posthog.com/project/116305/insights/5R9uGT1W)** — Avg time on page per `utm_campaign`
-
-## n8n Backend Services
-
-### Local Services (systemd unit on n8n server)
-
-After n8n 2.15.1 removed `n8n-nodes-base.executeCommand` and `n8n-nodes-base.localFileTrigger`, a standalone Node.js HTTP service was created to handle operations that require shell access or external libraries.
-
-**Location:** `/root/dads-clinic-backup/service/` on the n8n server
-**Managed by:** systemd service `clinic-service.service`
-**Listens on:** `127.0.0.1:3847` (localhost only, not exposed externally)
-
-#### Endpoints
-
-**POST `/validate`** — Phone number validation using `google-libphonenumber`
-- Input: `{ "phone": "962791234567" }` (no leading `+`)
-- Output: `{ "success": true, "phone": "+962791234567", "isValid": true, "isMobile": true, "message": 1 }`
-- Detects mobile vs landline, validates international number formats
-- Called by the n8n verification workflow's "Validate Phone Number" HTTP Request node
-- **Why standalone:** `google-libphonenumber` can't be installed inside n8n (dependency conflicts, removed on n8n updates)
-
-**POST `/send-sms`** — Async SMS sending via SSH to Termux phones
-- Input: `{ "phone": "+962791234567", "message": "Your code is 1234" }`
-- Output: `{ "success": true, "queued": true }` (returns immediately)
-- In the background: tries all 3 phones in parallel (`doctor.termux`, `assistant.termux`, `doctor2.termux`) with 10-second timeouts via SSH
-- Logs results to `/root/dads-clinic-queues/sms.log`
-- Called by the n8n verification workflow's "Send SMS Using Service" HTTP Request node
-- **Why async:** Sequential SSH with 30s timeouts per phone was blocking the n8n workflow for up to 90 seconds
-
-#### Setup & Maintenance
-
-```bash
-# On the n8n server:
-cd /root/dads-clinic-backup/service
-bash setup.sh    # npm install, install/restart systemd service
-systemctl status service   # check status
-journalctl -u service -f   # view logs
-```
-
-### n8n Workflow Changes (post-2.15.1 upgrade)
-
-**Removed node types and replacements:**
-- `n8n-nodes-base.executeCommand` → HTTP Request to `localhost:3847` or Code nodes
-- `n8n-nodes-base.localFileTrigger` → No longer needed (queues moved to n8n data tables)
-
-**Verification workflow** (`dwv7rpf8uHxyum02`):
-- Phone validation: 3-node executeCommand chain → single HTTP Request to `/validate` + Set node
-- SMS sending: executeCommand with SSH → HTTP Request to `/send-sms` (async)
-- Telegram notifications: executeCommand writing to CSV → Execute Workflow calling "Dads Clinic-Send Telegram Messages" subflow (`C2F9UQOSqoWTqCg8`)
-- Message queues: CSV files → n8n data tables (table `message_queue`, ID: `iPhhvNECkVRm88Ia`)
-- Booking completion: PostHog node fires `booking_completed` with phone as `distinct_id`
-
-**Telegram subflow** (`C2F9UQOSqoWTqCg8`):
-- Receives `telegram_recepients` (array) + `notification_message` (string)
-- Maps phone numbers to Telegram chat IDs via a Code node
-- Sends via Telegram node with `appendAttribution: false`
-- Created via n8n MCP `update_workflow` (small enough to safely replace via SDK)
-
-**User-Initiated Verification V2** (`wpSDqlKO2iMoUZZ7`, "Dads Clinic-Verify Phone Number 2"):
-
-A zero-cost phone verification system where the user sends a code TO the clinic instead of the clinic sending a code to the user. Eliminates SMS costs, abuse risk, and phone number input errors.
-
-**Endpoints:**
-- `POST /webhook/verify-v2-generate` — Creates a 6-char alphanumeric code (charset: `ABCDEFGHJKMNPQRSTUVWXYZ23456789`) + session ID, stores in `user_initiated_verification_codes` data table, returns `{ code, session_id }`
-- `POST /webhook/verify-v2-status` — Input: `{ session_id, code }`. Returns `{ verified: false }` (waiting), `{ verified: false, expired: true }` (>5 min), or `{ verified: true, phone, token }` (JWT)
-
-**Data table:** `user_initiated_verification_codes` (ID: `YF3BFLASWMIxuPgu`) — columns: `code`, `session_id`, `phone` (null until claimed). Uses built-in `createdAt` for expiry (5 min). Expired rows flushed inline on each generate call.
-
-**WhatsApp AI Assistant** (`XlYzvScd6xm3xlBI`, "Dads Clinic-WhatsApp AI Assistant"):
-
-An AI-powered WhatsApp assistant that handles incoming patient messages and verification code interception. Built with Claude Haiku 4.5 via the Anthropic API.
-
-**Flow:**
-1. WhatsApp Trigger receives message → Filter (text messages only) → Extract phone, text, sender name
-2. Check if message matches 6-char verification code pattern (case-insensitive, spaces ignored)
-3. **If code:** Look up in `user_initiated_verification_codes` table → set phone on match → reply with confirmation ("تم التحقق بنجاح!") or unknown code message ("هذا ليس رمز تحقق نعرفه.") → skip AI entirely
-4. **If not code:** Build prompt context → AI Agent (Claude Haiku 4.5, temperature 0.3) classifies intent → Structured Output Parser extracts `{ intent, reply }`
-5. Send WhatsApp reply to patient + Log to Telegram (tech support chat `211021550`)
-
-**Intent classification:**
-- `info` — clinic information or general questions → AI answers directly from embedded clinic data
-- `medical` — medical question needing the doctor → directs to doctor's number (+962799133299)
-- `administrative` — billing, reports, insurance → directs to secretary's number (+962798872899)
-- `booking` — appointment changes → directs to https://abuobaydatajjarrah.com/bookings/
-
-**System prompt** contains full clinic info (hours, location, specialties, fees, phone numbers) sourced from https://abuobaydatajjarrah.com/llms-ar.txt. The AI is instructed to respond in 2-3 sentences max, never give medical advice, and never pretend to be a doctor.
-
-**Cost:** ~$0.001 per message (Haiku 4.5). At 100 messages/day, roughly $3/month.
-
-**Credentials (auto-assigned):**
-- Anthropic API → Claude Haiku 4.5
-- WhatsApp Business → clinic phone number (ID: `943723358817193`)
-- Telegram → Dads Clinic Appointments Bot
-
-**Planned enhancements:**
-- **Frontend component (`PhoneVerificationV2.astro`):** In progress — calls V2 generate/poll endpoints, shows code + WhatsApp link, polls every 2s, falls back to V1 on expiry. Offered as "لا تعرف رقمك؟" link under existing phone input.
-- **Conversation history:** Create a `chat_history` data table (columns: `phone`, `history` as JSON array, `updated_at`). Load before AI call, save after. Keep last 10-20 exchanges per phone number to maintain context across messages.
-- **Booking via bot:** Use Cal.com API to check available slots and handle rescheduling directly in the WhatsApp conversation, without redirecting to the website.
-- **Media messages:** Handle images (e.g., patient sending a photo of a referral or test result) by forwarding to the doctor's Telegram with context.
-- **PostHog tracking:** Fire a `whatsapp_ai_reply` event with `intent` property to track what patients ask about and measure AI vs human handling ratio.
-- **SMS-based user-initiated verification:** Same V2 code pattern but user sends code via SMS instead of WhatsApp — extends V2 to users without WhatsApp.
-
-**n8n SDK learnings:**
-- Data table nodes **must** have `alwaysOutputData: true` enabled, otherwise flows terminate silently when a delete/get operation returns no rows.
-- Reference data tables via `mode: 'list'` (selecting from dropdown) rather than `mode: 'id'` — more human-readable when editing in the n8n UI.
-
-**Important:** The WhatsApp Trigger node auto-registers its production webhook URL with Meta via the API when the workflow is activated. You never need to manually configure the webhook URL in Meta's dashboard. The "test URL" feature in the n8n editor is for development only — to return to production mode, deactivate and reactivate the workflow.
-
-### SMS Gateway Architecture
-
-Android phones running Termux act as SMS gateways. They connect to the n8n server via reverse SSH tunnels through a VPS (`213.165.86.237`).
-
-| SSH Name | Phone Number | Tunnel Port | Status |
-|----------|-------------|-------------|--------|
-| `doctor.termux` | +962799133299 | 8024 | Active |
-| `assistant.termux` | +962798872899 | 8023 | Active |
-| `doctor2.termux` | +962799486661 | — | Active |
-
-Setup script: `sms-gateway/setup.sh` in the parent `dads-clinic` repo.
-SMS sending script on each phone: `~/send_sms.sh` (handles Arabic/non-Arabic segmentation, SIM selection, multi-part messages).
+6. [Ghost Visits by Source](https://eu.posthog.com/project/116305/insights/0wbhRUXg) — ghost vs total ad visits by `utm_source`
+7. [Campaign Quality](https://eu.posthog.com/project/116305/insights/5R9uGT1W) — avg time on page per `utm_campaign`
 
 ## Content Security Policy
 
-The `public/_headers` file defines CSP headers for Cloudflare Pages. When external services add new subdomains (e.g., Google Analytics regional endpoints, Cal.com embed subdomains), the CSP must be updated or browsers will block requests silently.
-
-**Current allowlist includes:**
-- `*.google-analytics.com` (covers regional endpoints like `region1.`)
+`public/_headers` defines CSP for Cloudflare Pages. Must whitelist:
+- `*.google-analytics.com` (regional endpoints)
 - `*.posthog.com`, `*.i.posthog.com`
-- `*.cal.com` (covers embed subdomains)
+- `*.cal.com` (embed subdomains)
 - `n8n.orwa.tech`
 
-If Cal.com or analytics suddenly break with "This content is blocked" errors, check `public/_headers` CSP first.
-
-## Files Modified
-
-| File | What was added |
-|------|---------------|
-| `src/components/common/PosthogAnalytics.astro` | Production-only gate, ad engagement tracker |
-| `src/components/booking/PhoneVerification.astro` | 6 booking funnel events, helper functions, `posthog.identify(phone)` |
-| `src/pages/book.astro` | Token validation + Cal.com opened events |
-| `src/pages/index.astro` | Cal.com opened event, WhatsApp CTA tracking |
-| `public/_headers` | CSP wildcards for Google Analytics, Cal.com subdomains |
+If analytics or Cal.com break with "This content is blocked", check CSP first.

--- a/context/analytics-and-tracking.md
+++ b/context/analytics-and-tracking.md
@@ -88,7 +88,7 @@ Zero overhead for organic visitors.
 ## PostHog Insights
 
 ### Booking (tag: `booking`)
-1. [Booking Funnel (Full)](https://eu.posthog.com/project/116305/insights/LGUWwM9U) — Phone Submitted → Code Sent → Verified → Cal.com → Booking Completed
+1. [Booking Funnel (Unified V1+V2)](https://eu.posthog.com/project/116305/insights/68NeDfUQ) — Verification Started → Verification Completed → Cal.com → Booking Completed (broken down by `verification_method`: `v1` or `v2`)
 2. [Phone Rejection Patterns](https://eu.posthog.com/project/116305/insights/37DxZVg8) — client-side rejections by `phone_raw`
 3. [Backend Rejection Reasons](https://eu.posthog.com/project/116305/insights/AoncriXj) — backend failures by `failure_reason`
 4. [WhatsApp Fallback](https://eu.posthog.com/project/116305/insights/0elBhZDK) — users who tried booking then clicked WhatsApp

--- a/context/analytics-and-tracking.md
+++ b/context/analytics-and-tracking.md
@@ -197,15 +197,25 @@ journalctl -u service -f   # view logs
 - Sends via Telegram node with `appendAttribution: false`
 - Created via n8n MCP `update_workflow` (small enough to safely replace via SDK)
 
+**User-Initiated Verification V2** (`wpSDqlKO2iMoUZZ7`, "Dads Clinic-Verify Phone Number 2"):
+
+A zero-cost phone verification system where the user sends a code TO the clinic instead of the clinic sending a code to the user. Eliminates SMS costs, abuse risk, and phone number input errors.
+
+**Endpoints:**
+- `POST /webhook/verify-v2-generate` — Creates a 6-char alphanumeric code (charset: `ABCDEFGHJKMNPQRSTUVWXYZ23456789`) + session ID, stores in `user_initiated_verification_codes` data table, returns `{ code, session_id }`
+- `POST /webhook/verify-v2-status` — Input: `{ session_id, code }`. Returns `{ verified: false }` (waiting), `{ verified: false, expired: true }` (>5 min), or `{ verified: true, phone, token }` (JWT)
+
+**Data table:** `user_initiated_verification_codes` (ID: `YF3BFLASWMIxuPgu`) — columns: `code`, `session_id`, `phone` (null until claimed). Uses built-in `createdAt` for expiry (5 min). Expired rows flushed inline on each generate call.
+
 **WhatsApp AI Assistant** (`XlYzvScd6xm3xlBI`, "Dads Clinic-WhatsApp AI Assistant"):
 
-An AI-powered WhatsApp assistant that handles incoming patient messages. Built with Claude Haiku 4.5 via the Anthropic API.
+An AI-powered WhatsApp assistant that handles incoming patient messages and verification code interception. Built with Claude Haiku 4.5 via the Anthropic API.
 
 **Flow:**
 1. WhatsApp Trigger receives message → Filter (text messages only) → Extract phone, text, sender name
-2. Build prompt context (currently no history — see "Planned" below)
-3. AI Agent (Claude Haiku 4.5, temperature 0.3) classifies intent and generates Arabic reply
-4. Structured Output Parser extracts `{ intent, reply }` from the AI response
+2. Check if message matches 6-char verification code pattern (case-insensitive, spaces ignored)
+3. **If code:** Look up in `user_initiated_verification_codes` table → set phone on match → reply with confirmation ("تم التحقق بنجاح!") or unknown code message ("هذا ليس رمز تحقق نعرفه.") → skip AI entirely
+4. **If not code:** Build prompt context → AI Agent (Claude Haiku 4.5, temperature 0.3) classifies intent → Structured Output Parser extracts `{ intent, reply }`
 5. Send WhatsApp reply to patient + Log to Telegram (tech support chat `211021550`)
 
 **Intent classification:**
@@ -224,10 +234,16 @@ An AI-powered WhatsApp assistant that handles incoming patient messages. Built w
 - Telegram → Dads Clinic Appointments Bot
 
 **Planned enhancements:**
+- **Frontend component (`PhoneVerificationV2.astro`):** In progress — calls V2 generate/poll endpoints, shows code + WhatsApp link, polls every 2s, falls back to V1 on expiry. Offered as "لا تعرف رقمك؟" link under existing phone input.
 - **Conversation history:** Create a `chat_history` data table (columns: `phone`, `history` as JSON array, `updated_at`). Load before AI call, save after. Keep last 10-20 exchanges per phone number to maintain context across messages.
 - **Booking via bot:** Use Cal.com API to check available slots and handle rescheduling directly in the WhatsApp conversation, without redirecting to the website.
 - **Media messages:** Handle images (e.g., patient sending a photo of a referral or test result) by forwarding to the doctor's Telegram with context.
 - **PostHog tracking:** Fire a `whatsapp_ai_reply` event with `intent` property to track what patients ask about and measure AI vs human handling ratio.
+- **SMS-based user-initiated verification:** Same V2 code pattern but user sends code via SMS instead of WhatsApp — extends V2 to users without WhatsApp.
+
+**n8n SDK learnings:**
+- Data table nodes **must** have `alwaysOutputData: true` enabled, otherwise flows terminate silently when a delete/get operation returns no rows.
+- Reference data tables via `mode: 'list'` (selecting from dropdown) rather than `mode: 'id'` — more human-readable when editing in the n8n UI.
 
 **Important:** The WhatsApp Trigger node auto-registers its production webhook URL with Meta via the API when the workflow is activated. You never need to manually configure the webhook URL in Meta's dashboard. The "test URL" feature in the n8n editor is for development only — to return to production mode, deactivate and reactivate the workflow.
 

--- a/context/booking-system.md
+++ b/context/booking-system.md
@@ -12,10 +12,13 @@ The booking system integrates phone verification with Cal.com scheduling. Users 
 
 ```
 src/components/booking/
-├── PhoneVerification.astro  # Phone input + OTP verification flow
-├── PhoneSelector.astro      # Shows verified phone with proceed/change options
-└── BookingCard.astro        # Displays booking details with calendar actions
+├── PhoneVerification.astro    # V1: Phone input + OTP verification flow
+├── PhoneVerificationV2.astro  # V2: User-initiated verification via WhatsApp code
+├── PhoneSelector.astro        # Shows verified phone with proceed/change options
+└── BookingCard.astro          # Displays booking details with calendar actions
 ```
+
+**V2 Verification** (user-initiated): User sends a 6-char code to the clinic's WhatsApp. Zero cost, no phone input needed. Offered as "لا تعرف رقمك؟" link under V1 on `/book`. Falls back to V1 on expiry (5 min). See [context/n8n-backend.md](n8n-backend.md) for backend details.
 
 ### Pages
 

--- a/context/n8n-backend.md
+++ b/context/n8n-backend.md
@@ -1,0 +1,165 @@
+# n8n Backend Infrastructure
+
+## Overview
+
+The clinic's backend runs on a self-hosted n8n instance at `https://n8n.orwa.tech`. It handles phone verification, booking confirmation, SMS/WhatsApp messaging, Telegram notifications, and AI-powered WhatsApp conversations.
+
+**n8n version:** 2.15.1 (self-hosted). This version removed `executeCommand` and `localFileTrigger` nodes — see "Local Services" below for how we replaced them.
+
+## n8n Workflows
+
+| Workflow | ID | Purpose |
+|----------|------|---------|
+| Verify Phone Number (V1) | `dwv7rpf8uHxyum02` | Original phone verification: send code via SMS/WhatsApp, verify code, issue JWT |
+| Verify Phone Number (V2) | `wpSDqlKO2iMoUZZ7` | User-initiated verification: generate code for user to send via WhatsApp |
+| WhatsApp AI Assistant | `XlYzvScd6xm3xlBI` | Claude Haiku 4.5 chatbot + verification code interception |
+| Send Telegram Messages | `C2F9UQOSqoWTqCg8` | Subflow: maps phone numbers to Telegram chat IDs, sends messages |
+| Send Reminders | `WiqM8fag3FvWvW6t` | Appointment reminders via WhatsApp/SMS |
+| Message Queuing | `n1xrgJXoX6d74bjo` | Message dispatch and queuing (deprecated) |
+
+### Verify Phone Number V1 (`dwv7rpf8uHxyum02`)
+
+The original verification flow. User enters phone number, receives a 4-digit code via SMS or WhatsApp, enters code, gets a JWT token.
+
+Key webhook endpoints:
+- `POST /webhook/c6c748c4-...` — Send verification code
+- `POST /webhook/9298e44c-...` — Verify code
+- `POST /webhook/b1ac96a5-...` — Validate existing JWT token
+- `POST /webhook/80a3c67b-...` — Auto-confirm Cal.com appointments
+- `POST /webhook/4900724b-...` — Get upcoming bookings from token
+
+After confirming a booking on Cal.com, fires `booking_completed` event to PostHog with the phone number as `distinct_id`.
+
+### Verify Phone Number V2 (`wpSDqlKO2iMoUZZ7`)
+
+User-initiated verification — the user sends a code TO the clinic via WhatsApp instead of receiving one. Zero cost, abuse-proof, no phone input needed.
+
+**Endpoints:**
+- `POST /webhook/verify-v2-generate` — Creates 6-char code (charset: `ABCDEFGHJKMNPQRSTUVWXYZ23456789`, no ambiguous chars) + 32-char hex session ID. Returns `{ code, session_id }`.
+- `POST /webhook/verify-v2-status` — Input: `{ session_id, code }`. Returns:
+  - `{ verified: false }` — waiting for WhatsApp message
+  - `{ verified: false, expired: true }` — code older than 5 minutes
+  - `{ verified: true, phone: "+962...", token: "eyJ..." }` — verified, JWT issued
+
+**Data table:** `user_initiated_verification_codes` (ID: `YF3BFLASWMIxuPgu`) — columns: `code`, `session_id`, `phone` (null until claimed). Uses built-in `createdAt` for expiry. Expired rows flushed inline on each generate call.
+
+### WhatsApp AI Assistant (`XlYzvScd6xm3xlBI`)
+
+AI-powered WhatsApp responder with verification code interception.
+
+**Flow:**
+1. WhatsApp Trigger → Filter text messages → Extract phone, text, sender name
+2. Check if message matches 6-char verification code pattern (case-insensitive, spaces ignored)
+3. **If code:** Look up in V2 data table → set phone on match → reply confirmation or "unknown code"
+4. **If not code:** Claude Haiku 4.5 classifies intent and generates Arabic reply
+
+**Intent classification:**
+- `info` — clinic questions → AI answers from embedded data
+- `medical` — needs doctor → directs to +962799133299
+- `administrative` — billing/insurance → directs to +962798872899
+- `booking` — appointment changes → directs to https://abuobaydatajjarrah.com/bookings/
+
+**System prompt** sourced from `https://abuobaydatajjarrah.com/llms-ar.txt`. AI responds in 2-3 sentences, never gives medical advice.
+
+**Cost:** ~$0.001/message (Haiku 4.5). ~$3/month at 100 messages/day.
+
+**Credentials:** Anthropic API, WhatsApp Business (phone ID: `943723358817193`), Telegram (Dads Clinic Appointments Bot).
+
+**WhatsApp Trigger behavior:** The node auto-registers its production webhook URL with Meta when the workflow is activated. Never configure this manually in Meta's dashboard. To switch from test back to production mode, deactivate and reactivate the workflow.
+
+### Send Telegram Messages (`C2F9UQOSqoWTqCg8`)
+
+Subflow called by V1 verification workflow for booking rejection and abuse alert notifications.
+- Input: `telegram_recepients` (array of phone numbers), `notification_message` (string)
+- Maps phone numbers to Telegram chat IDs via a hardcoded lookup table in a Code node
+- Created via n8n MCP SDK (small enough to safely replace via SDK)
+
+## Local Services (systemd)
+
+A standalone Node.js HTTP service runs alongside n8n to handle operations removed from n8n 2.15.1.
+
+**Local Location:** `./n8n/service` in this repository where n8n is a submodule repo
+**Remote Location:** `/root/dads-clinic-backup/service/` on the n8n server
+**systemd unit:** `clinic-service.service`
+**Listens on:** `127.0.0.1:3847` (localhost only)
+
+### n8n workflow backup system (prior to MCP)
+
+The n8n submodule repository inside of the website repository contains a backup script that used
+to be used to backup n8n workflows tagged with the `dads-clinic` and `production` labels.
+
+The remote machine also has `/opt/n8n.env` which contains the environmnt for the n8n systemd service
+(e.g. this is the place where one might need to add `NODE_FUNCTION_ALLOW_BUILTIN=crypto`, for example,
+to enable the builtin function `crypto`). Sometimes this environment will need to be changed. It is
+not currently admitted to version control.
+
+As a good practice, the user has to run `ssh root@n8n ./backup.sh 'commit message'` periodically 
+(while connected to VPN) to backup the workflows and commit them to version control under the n8n 
+submodule repo. This has to be followed by pulling from the n8n folder locally to pull the changes
+pushed from the remote.
+
+The `backup.sh` home-directory script referenced from the SSH command above contains the following:
+
+```
+cd dads-clinic-backup && ./backup.sh && git add . && git commit -m "${*:-Synced workflows}" && git push
+```
+
+The backup.sh file referenced above can hence be found at `./n8n/backup.sh` in this repository, which
+is different from the home-directory `backup.sh` script.
+
+### Endpoints
+
+**POST `/validate`** — Phone number validation via `google-libphonenumber`
+- Input: `{ "phone": "962791234567" }` (no leading `+`)
+- Output: `{ "success": true, "phone": "+962791234567", "isValid": true, "isMobile": true, "message": 1 }`
+- Why standalone: `google-libphonenumber` has dependency conflicts with n8n, gets removed on updates
+
+**POST `/send-sms`** — Async SMS sending via SSH to Termux phones
+- Input: `{ "phone": "+962791234567", "message": "..." }`
+- Output: `{ "success": true, "queued": true }` (returns immediately)
+- Background: tries all 3 phones in parallel with 10s timeouts
+- Logs to `/root/dads-clinic-queues/sms.log`
+
+### Setup
+
+```bash
+cd /root/dads-clinic-backup/service
+bash setup.sh    # npm install, install/restart systemd service
+systemctl status clinic-service
+journalctl -u clinic-service -f
+```
+
+## SMS Gateway
+
+Android phones running Termux act as SMS gateways via reverse SSH tunnels through a VPS.
+
+| SSH Name | Phone Number | Tunnel Port |
+|----------|-------------|-------------|
+| `doctor.termux` | +962799133299 | 8024 |
+| `assistant.termux` | +962798872899 | 8023 |
+| `doctor2.termux` | +962799486661 | — |
+
+Setup: `sms-gateway/setup.sh` in the parent `dads-clinic` repo.
+Per-phone script: `~/send_sms.sh` (handles Arabic segmentation, SIM selection, multi-part messages).
+
+## n8n MCP Usage
+
+- **`mcp__n8n-mcp__*`** tools for inspecting and modifying workflows
+- `update_workflow` replaces the **entire** workflow via SDK code — too risky for large workflows (40+ nodes). For targeted changes, guide the user through the n8n UI
+- For small workflows (< 15 nodes), SDK replacement via MCP works well (proven with Telegram subflow and WhatsApp AI assistant)
+
+## n8n SDK Learnings
+
+These are hard-won lessons from building workflows via the MCP SDK:
+
+- **`alwaysOutputData: true`** is required on all Data Table nodes. Without it, flows terminate silently when a delete/get returns no rows — the node produces zero items and downstream nodes never execute.
+- **Reference data tables via `mode: 'list'`** (dropdown selection) not `mode: 'id'`. The list mode stores the human-readable table name alongside the ID, making workflows readable when editing in the n8n UI.
+- **WhatsApp Trigger** auto-registers its webhook URL with Meta on activation. Using the "test" URL in the editor overrides this. To return to production, deactivate and reactivate the workflow.
+- **`executeCommand` and `localFileTrigger`** were removed in n8n 2.15.1. No replacements exist — use HTTP Request nodes calling external services or Code nodes with `child_process`.
+
+## Planned Enhancements
+
+- **Conversation history** for WhatsApp AI: `chat_history` data table, load/save per phone number, keep last 10-20 exchanges
+- **Booking via WhatsApp bot:** Cal.com API integration for checking slots and rescheduling in conversation
+- **Media messages:** Forward patient images to doctor's Telegram with context
+- **SMS-based V2 verification:** Same user-initiated code pattern but via SMS instead of WhatsApp

--- a/src/components/booking/PhoneVerification.astro
+++ b/src/components/booking/PhoneVerification.astro
@@ -279,6 +279,10 @@ const VERIFY_CODE_ENDPOINT = 'https://n8n.orwa.tech/webhook/9298e44c-0a64-49ea-9
           method,
           booking_type: bookingType,
         });
+        window.posthog?.capture('booking_verification_started', {
+          verification_method: 'v1',
+          booking_type: bookingType,
+        });
 
         if (!phone || phone.length < 10) {
           window.posthog?.capture('booking_phone_client_rejected', {
@@ -371,6 +375,10 @@ const VERIFY_CODE_ENDPOINT = 'https://n8n.orwa.tech/webhook/9298e44c-0a64-49ea-9
             window.posthog?.capture('booking_verified', {
               method,
               is_jordan: phone.startsWith('962'),
+              booking_type: bookingType,
+            });
+            window.posthog?.capture('booking_verification_completed', {
+              verification_method: 'v1',
               booking_type: bookingType,
             });
             // Identify user by phone so backend booking_completed event correlates

--- a/src/components/booking/PhoneVerificationV2.astro
+++ b/src/components/booking/PhoneVerificationV2.astro
@@ -184,6 +184,7 @@ const WHATSAPP_PHONE = '962782760965';
 
           if (window.posthog) {
             window.posthog.capture('verify_v2_code_matched', { booking_type: getBookingType() });
+            window.posthog.capture('booking_verification_completed', { verification_method: 'v2', booking_type: getBookingType() });
             window.posthog.identify(phone);
           }
 
@@ -229,6 +230,7 @@ const WHATSAPP_PHONE = '962782760965';
 
               if (window.posthog) {
                 window.posthog.capture('verify_v2_code_generated', { booking_type: getBookingType() });
+                window.posthog.capture('booking_verification_started', { verification_method: 'v2', booking_type: getBookingType() });
               }
             } else {
               handleExpired();

--- a/src/components/booking/PhoneVerificationV2.astro
+++ b/src/components/booking/PhoneVerificationV2.astro
@@ -1,0 +1,281 @@
+---
+/**
+ * PhoneVerificationV2 Component
+ *
+ * User-initiated phone verification: the user sends a code to the clinic's
+ * WhatsApp number instead of the clinic sending a code to the user.
+ * Zero cost, abuse-proof, no phone number input needed.
+ *
+ * Dispatches custom events:
+ * - 'phone-verified': When verification succeeds, includes { token, phone } in detail
+ * - 'verification-expired': When the 5-minute window expires
+ *
+ * Usage:
+ * <PhoneVerificationV2 id="my-verification-v2" />
+ */
+
+interface Props {
+  id?: string;
+  class?: string;
+}
+
+const { id = 'phone-verification-v2', class: className = '' } = Astro.props;
+
+const GENERATE_ENDPOINT = 'https://n8n.orwa.tech/webhook/verify-v2-generate';
+const STATUS_ENDPOINT = 'https://n8n.orwa.tech/webhook/verify-v2-status';
+const WHATSAPP_PHONE = '962782760965';
+---
+
+<div id={id} class={`phone-verification-v2 ${className}`}
+  data-generate-endpoint={GENERATE_ENDPOINT}
+  data-status-endpoint={STATUS_ENDPOINT}
+  data-whatsapp-phone={WHATSAPP_PHONE}
+>
+  <!-- Loading State -->
+  <div class="v2-loading text-center py-8">
+    <div class="inline-block animate-spin rounded-full h-8 w-8 border-4 border-primary border-t-transparent"></div>
+    <p class="mt-4 text-muted dark:text-slate-400">جارٍ إنشاء رمز التحقق...</p>
+  </div>
+
+  <!-- Code Display Section (hidden until code is generated) -->
+  <div class="v2-code-section hidden">
+    <div class="text-center mb-6">
+      <p class="text-sm text-muted dark:text-slate-400 mb-3">
+        أرسل هذا الرمز عبر واتساب للتحقق من رقمك
+      </p>
+
+      <!-- The Code -->
+      <div class="v2-code-display text-4xl font-bold tracking-[0.3em] font-mono py-4 px-6 bg-gray-100 dark:bg-gray-800 rounded-xl select-all" dir="ltr">
+        ------
+      </div>
+
+      <!-- Countdown Timer -->
+      <div class="v2-timer mt-3 text-sm text-muted dark:text-slate-400">
+        <span class="v2-timer-text">صالح لمدة ٥ دقائق</span>
+      </div>
+    </div>
+
+    <!-- WhatsApp Link/Button -->
+    <a
+      class="v2-whatsapp-link btn-primary w-full py-3 flex flex-col items-center justify-center gap-1 text-white no-underline"
+      href="#"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span class="flex items-center gap-2">
+        <span>أرسل الرمز عبر واتساب</span>
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+        </svg>
+      </span>
+      <span class="v2-phone-display text-sm opacity-80" dir="ltr" style="font-family: 'New Rail Alphabet', monospace;">
+        <!-- Phone number filled by JS -->
+      </span>
+    </a>
+
+    <!-- Waiting indicator -->
+    <div class="v2-waiting mt-6 text-center">
+      <div class="inline-flex items-center gap-2 text-sm text-muted dark:text-slate-400">
+        <div class="animate-pulse w-2 h-2 rounded-full bg-primary"></div>
+        <span>في انتظار استلام الرمز...</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Success State -->
+  <div class="v2-success hidden text-center py-4">
+    <div class="text-green-600 dark:text-green-400 mb-2">
+      <svg class="w-12 h-12 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    </div>
+    <p class="text-green-700 dark:text-green-300 font-medium">تم التحقق بنجاح!</p>
+  </div>
+
+  <!-- Expired State -->
+  <div class="v2-expired hidden text-center py-4">
+    <p class="text-red-600 dark:text-red-400 text-sm mb-3">انتهت صلاحية الرمز</p>
+  </div>
+</div>
+
+<script is:inline>
+  /* eslint-disable no-var */
+  (function() {
+    var POLL_INTERVAL = 2000;
+    var CODE_LIFETIME = 5 * 60 * 1000;
+
+    function initPhoneVerificationV2() {
+      document.querySelectorAll('.phone-verification-v2').forEach(function(container) {
+        if (container.dataset.initialized === 'true') return;
+        container.dataset.initialized = 'true';
+
+        var generateEndpoint = container.dataset.generateEndpoint;
+        var statusEndpoint = container.dataset.statusEndpoint;
+        var whatsappPhone = container.dataset.whatsappPhone;
+
+        var loadingEl = container.querySelector('.v2-loading');
+        var codeSectionEl = container.querySelector('.v2-code-section');
+        var codeDisplayEl = container.querySelector('.v2-code-display');
+        var timerTextEl = container.querySelector('.v2-timer-text');
+        var whatsappLinkEl = container.querySelector('.v2-whatsapp-link');
+        var phoneDisplayEl = whatsappLinkEl.querySelector('.v2-phone-display');
+        var waitingEl = container.querySelector('.v2-waiting');
+        var successEl = container.querySelector('.v2-success');
+        var expiredEl = container.querySelector('.v2-expired');
+
+        var sessionId = null;
+        var code = null;
+        var pollTimer = null;
+        var countdownTimer = null;
+        var expiresAt = null;
+
+        function formatPhone(digits) {
+          return '+' + digits.replace(/(\d{3})(\d{1})(\d{4})(\d{4})/, '$1 $2 $3 $4');
+        }
+
+        function showSection(section) {
+          loadingEl.classList.add('hidden');
+          codeSectionEl.classList.add('hidden');
+          successEl.classList.add('hidden');
+          expiredEl.classList.add('hidden');
+          section.classList.remove('hidden');
+        }
+
+        function updateCountdown() {
+          if (!expiresAt) return;
+          var remaining = Math.max(0, expiresAt - Date.now());
+          var minutes = Math.floor(remaining / 60000);
+          var seconds = Math.floor((remaining % 60000) / 1000);
+
+          // Convert to Arabic numerals
+          var arabicNums = function(n) {
+            return String(n).replace(/[0-9]/g, function(d) {
+              return String.fromCharCode(0x0660 + parseInt(d));
+            });
+          };
+
+          if (remaining <= 0) {
+            handleExpired();
+            return;
+          }
+
+          timerTextEl.textContent = 'صالح لمدة ' + arabicNums(minutes) + ':' + arabicNums(seconds < 10 ? '0' + seconds : seconds);
+        }
+
+        function startPolling() {
+          if (pollTimer) clearInterval(pollTimer);
+          pollTimer = setInterval(pollStatus, POLL_INTERVAL);
+        }
+
+        function stopPolling() {
+          if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+          if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
+        }
+
+        function handleExpired() {
+          stopPolling();
+          showSection(expiredEl);
+          container.dispatchEvent(new CustomEvent('verification-expired', { bubbles: true }));
+        }
+
+        function handleVerified(phone, token) {
+          stopPolling();
+          showSection(successEl);
+
+          if (window.posthog) {
+            window.posthog.capture('verify_v2_code_matched', { booking_type: getBookingType() });
+            window.posthog.identify(phone);
+          }
+
+          container.dispatchEvent(new CustomEvent('phone-verified', {
+            bubbles: true,
+            detail: { token: token, phone: phone }
+          }));
+        }
+
+        function getBookingType() {
+          var params = new URLSearchParams(window.location.search);
+          return params.get('type') === 'remote' ? 'remote' : 'clinic';
+        }
+
+        async function generateCode() {
+          showSection(loadingEl);
+          try {
+            var response = await fetch(generateEndpoint, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: '{}'
+            });
+            var data = await response.json();
+
+            if (data.code && data.session_id) {
+              sessionId = data.session_id;
+              code = data.code;
+              expiresAt = Date.now() + CODE_LIFETIME;
+
+              // Display the code with spacing for readability
+              codeDisplayEl.textContent = code.split('').join(' ');
+
+              // Set WhatsApp link
+              whatsappLinkEl.href = 'https://wa.me/' + whatsappPhone + '?text=' + encodeURIComponent(code);
+
+              // Show phone number for two-device scenario
+              phoneDisplayEl.textContent = formatPhone(whatsappPhone);
+
+              showSection(codeSectionEl);
+              startPolling();
+              countdownTimer = setInterval(updateCountdown, 1000);
+              updateCountdown();
+
+              if (window.posthog) {
+                window.posthog.capture('verify_v2_code_generated', { booking_type: getBookingType() });
+              }
+            } else {
+              handleExpired();
+            }
+          } catch (e) {
+            handleExpired();
+          }
+        }
+
+        async function pollStatus() {
+          if (!sessionId || !code) return;
+          try {
+            var response = await fetch(statusEndpoint, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ session_id: sessionId, code: code })
+            });
+            var data = await response.json();
+
+            if (data.verified && data.token && data.phone) {
+              handleVerified(data.phone, data.token);
+            } else if (data.expired) {
+              handleExpired();
+            }
+            // else: not verified yet, keep polling
+          } catch (e) {
+            // Network error, keep polling
+          }
+        }
+
+        // Start the flow
+        generateCode();
+      });
+    }
+
+    // Initialize on page load and View Transitions
+    document.addEventListener('astro:page-load', initPhoneVerificationV2);
+    if (document.readyState !== 'loading') {
+      initPhoneVerificationV2();
+    } else {
+      document.addEventListener('DOMContentLoaded', initPhoneVerificationV2);
+    }
+  })();
+</script>
+
+<style is:global>
+  .phone-verification-v2 .v2-code-display {
+    font-family: 'New Rail Alphabet', monospace !important;
+  }
+</style>


### PR DESCRIPTION
## ما الجديد؟

أضفنا طريقة جديدة وأسهل للتحقق من رقم الهاتف عند حجز موعد. بدلاً من إدخال رقم الهاتف يدويًا وانتظار رمز تحقق عبر رسالة نصية، يمكن للمريض الآن التحقق بخطوة واحدة عبر واتساب.

## كيف تعمل؟

١. عند صفحة الحجز، يضغط المريض على رابط **"لا تعرف رقمك؟ طريقة أسهل عبر واتساب"**

<!-- 📸 صورة ١: شاشة الحجز مع رابط الطريقة الجديدة -->
<img width="456" height="464" alt="Screenshot at Apr 17 23-09-31" src="https://github.com/user-attachments/assets/ddd46a3d-bb7a-491a-b85b-39ebfde635a1" />

٢. يظهر رمز مكون من ٦ أحرف مع زر واتساب يحتوي على رقم العيادة

<!-- 📸 صورة ٢: شاشة الرمز مع زر واتساب -->
<img width="453" height="485" alt="Screenshot at Apr 17 23-09-45" src="https://github.com/user-attachments/assets/58b52b27-7588-44fb-b1ff-c31ff799672f" />

٣. يضغط المريض على الزر → يفتح واتساب تلقائيًا مع الرمز جاهزًا للإرسال → يضغط إرسال
٤. خلال ثانيتين يتعرف الموقع على الرقم تلقائيًا ويفتح شاشة حجز الموعد

## لماذا هذا أسهل؟

- **لا حاجة لإدخال رقم الهاتف يدويًا** — الرقم يُستخرج تلقائيًا من واتساب
- **لا حاجة لانتظار رسالة نصية** وإدخال رمز التحقق
- **تجربة سلسة على الجوال** — ضغطة واحدة تفتح واتساب، ضغطة ثانية ترسل الرمز، والموقع يتعرف على الرقم فورًا
- **مجانية تمامًا** — لا تكلفة رسائل نصية أو واتساب لأن المريض هو من يرسل الرسالة

## ملاحظات

- الطريقة القديمة (إدخال الرقم + رمز التحقق) لا تزال متاحة كخيار أساسي
- الرمز صالح لمدة ٥ دقائق فقط — بعدها يعود الموقع تلقائيًا للطريقة القديمة
- يعمل أيضًا في حالة استخدام جهازين (مثلاً: الموقع على اللابتوب والواتساب على الجوال) — يقرأ المريض الرمز ورقم الهاتف من الشاشة ويرسلهما يدويًا

/cc @mamouneyya @SufianDira @mumendiraneyya 

🤖 برمجته [سوسن](https://claude.com/claude-code)